### PR TITLE
Resize image embedding to 256 dim

### DIFF
--- a/tokenizers/image_tokenizer.py
+++ b/tokenizers/image_tokenizer.py
@@ -108,5 +108,5 @@ class RT1ImageTokenizer(tf.keras.layers.Layer):
       tokens of shape (b, num_tokens, emedding_dim)
     """
     image_tokens = self._tokenizer(image, context=context, training=training)
-    image_tokens = tf.reshape(image_tokens, [-1, 81, 512])
+    image_tokens = tf.reshape(image_tokens, [-1, 81, 256])
     return image_tokens


### PR DESCRIPTION
This PR changes the existing get_image_embedding function to resize the image embedding to 256 dim before returning it. This should improve performance and accuracy of image recognition tasks.